### PR TITLE
Bump version to 2.12.1

### DIFF
--- a/custom_components/dpd/manifest.json
+++ b/custom_components/dpd/manifest.json
@@ -1,7 +1,9 @@
 {
   "domain": "dpd",
   "name": "DPD & BRT Italy",
-  "codeowners": ["@peternijssen"],
+  "codeowners": [
+    "@peternijssen"
+  ],
   "config_flow": true,
   "documentation": "https://github.com/ha-parcel-integrations/ha-dpd",
   "integration_type": "hub",
@@ -9,5 +11,5 @@
   "issue_tracker": "https://github.com/ha-parcel-integrations/ha-dpd/issues",
   "quality_scale": "silver",
   "requirements": [],
-  "version": "2.12.0"
+  "version": "2.12.1"
 }


### PR DESCRIPTION
## Other improvements
- maintenance release: attach the HACS release archive

---

📦 [See every supported carrier](https://ha-parcel-integrations.github.io/carriers/) — new ones land regularly.
💛 [Support the project](https://ha-parcel-integrations.github.io/sponsor/)