### PR TITLE
Bump version to 2.13.0

### DIFF
--- a/custom_components/dpd/manifest.json
+++ b/custom_components/dpd/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/ha-parcel-integrations/ha-dpd/issues",
   "quality_scale": "silver",
   "requirements": [],
-  "version": "2.12.1"
+  "version": "2.13.0"
 }


### PR DESCRIPTION
## New features
- remove the "Refresh every" setting and always poll DPD on the adaptive, status-driven schedule that used to be the "Automatic" choice: faster while a parcel is out for delivery, slower while it is on its way, and quiet overnight apart from two catch-up checks, with your account still checked regularly so new shipments show up on their own; this applies to every DPD backend, including Germany and Poland, and existing installs on a fixed interval move over automatically with nothing to change
- add support for DPD Poland: select Poland during setup and sign in with your phone number and a one-time SMS code (no DPD account email/password needed for this country), with parcels showing delivery-window and history data the same way as other DPD countries; this ships ahead of a real-parcel verification pass, so status labels are provisional — please open an issue if anything looks wrong

---

📦 [See every supported carrier](https://ha-parcel-integrations.github.io/carriers/) — new ones land regularly.
💛 [Support the project](https://ha-parcel-integrations.github.io/sponsor/)